### PR TITLE
Add Card Reference Controller

### DIFF
--- a/server/Controllers/CardController.cs
+++ b/server/Controllers/CardController.cs
@@ -6,14 +6,20 @@ namespace CardboardArchivistApi.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class CardController(ICardService cardService) : ControllerBase
+public class CardController(ICardService cardService, IReferenceService referenceService) : ControllerBase
 {
     private readonly ICardService _cardService = cardService;
+    private readonly IReferenceService _referenceService = referenceService;
 
     [HttpPost]
-    public ActionResult<string?> Add(Card card) 
+    public ActionResult<string?> Add(AddCard card) 
     {
-        string? newCardId = _cardService.Create(card);
+        Card newCard = new()
+        {
+            ReferenceId = new Guid(card.ReferenceId),
+            DeckId = !string.IsNullOrEmpty(card.DeckId) ? new Guid(card.DeckId) : null,
+        };
+        string? newCardId = _cardService.Create(newCard);
         if (newCardId is null)
             return BadRequest();
         string newCardUri = GetUri(newCardId);
@@ -53,9 +59,9 @@ public class CardController(ICardService cardService) : ControllerBase
         // if (_deckService.Get(card.DeckId) is null)
         //  return BadRequest(new { msg = "Invalid Deck ID" });
         _cardService.Update(new Card() {
-            UUID = id,
-            ReferenceUUID = card.ReferenceUUID,
-            DeckUUID = card.DeckUUID
+            Id = id,
+            ReferenceId = card.ReferenceId,
+            DeckId = card.DeckId
         });
         return Ok();
     }

--- a/server/Controllers/CardController.cs
+++ b/server/Controllers/CardController.cs
@@ -1,8 +1,8 @@
-using CardboardArchivistAPI.Models.Collection;
-using CardboardArchivistAPI.Services;
+using CardboardArchivistApi.Models.Collection;
+using CardboardArchivistApi.Services;
 using Microsoft.AspNetCore.Mvc;
 
-namespace CardboardArchivistAPI.Controllers;
+namespace CardboardArchivistApi.Controllers;
 
 [ApiController]
 [Route("[controller]")]

--- a/server/Controllers/ReferenceController.cs
+++ b/server/Controllers/ReferenceController.cs
@@ -1,0 +1,22 @@
+using CardboardArchivistApi.Models.Reference;
+using CardboardArchivistApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CardboardArchivistApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ReferenceController(IReferenceService referenceService) : ControllerBase
+{
+    private readonly IReferenceService _referenceService = referenceService;
+
+    [HttpGet]
+    [Route("{id}")]
+    public ActionResult<Card> GetCard(string id)
+    {
+        Card? card = _referenceService.GetCard(new Guid(id));
+        if (card is null)
+            return NotFound();
+        return Ok(card);
+    }
+}

--- a/server/Controllers/ReferenceController.cs
+++ b/server/Controllers/ReferenceController.cs
@@ -19,4 +19,11 @@ public class ReferenceController(IReferenceService referenceService) : Controlle
             return NotFound();
         return Ok(card);
     }
+
+    [HttpPost]
+    [Route("search")]
+    public ActionResult<List<Card>> SearchCards(SearchCards searchCards)
+    {
+        return Ok(_referenceService.SearchCards(searchCards));
+    }
 }

--- a/server/Models/Collection/AddCard.cs
+++ b/server/Models/Collection/AddCard.cs
@@ -1,0 +1,7 @@
+namespace CardboardArchivistApi.Models.Collection;
+
+public class AddCard
+{
+    public required string ReferenceId { get; set; }
+    public string? DeckId { get; set; }
+}

--- a/server/Models/Collection/Card.cs
+++ b/server/Models/Collection/Card.cs
@@ -1,4 +1,4 @@
-namespace CardboardArchivistAPI.Models.Collection;
+namespace CardboardArchivistApi.Models.Collection;
 
 public class Card
 {

--- a/server/Models/Collection/Card.cs
+++ b/server/Models/Collection/Card.cs
@@ -2,20 +2,13 @@ namespace CardboardArchivistApi.Models.Collection;
 
 public class Card
 {
-    public string? UUID { get; set; }
+    public string? Id { get; set; }
 
     // The UUID of the card in the reference database. This is where we get all the card's info such as the name, rules text, set info, etc.
-    public required string ReferenceUUID { get; set; }
+    public required Guid ReferenceId { get; set; }
 
     // The Deck to which this card belongs. Each card can only belong to one deck. If null, the card is in the general collection.
-    public string? DeckUUID { get; set; }
+    public Guid? DeckId { get; set; }
 
     // TODO: Add support for card condition (Mint, Near Mint, Excellent, Good, Damaged, etc.)
-
-    // public Card(string UUID, string referenceUUID, string? deckUUID)
-    // {
-    //     this.UUID = UUID;
-    //     ReferenceUUID = referenceUUID;
-    //     DeckUUID = deckUUID;
-    // }
 }

--- a/server/Models/Collection/Deck.cs
+++ b/server/Models/Collection/Deck.cs
@@ -1,4 +1,4 @@
-namespace CardboardArchivistAPI.Models.Collection;
+namespace CardboardArchivistApi.Models.Collection;
 
 public class Deck
 {

--- a/server/Models/Reference/Card.cs
+++ b/server/Models/Reference/Card.cs
@@ -3,12 +3,12 @@ namespace CardboardArchivistApi.Models.Reference;
 
 public class Card
 {
-    public string CollectorNumber { get; set; }
-    public string FoilType { get; set; }
-    public string Language { get; set; }
-    public string Name { get; set; }
-    public string ScryfallApiUri { get; set; }
-    public Guid ScryfallId { get; set; }
-    public string ScryfallUri { get; set; }
-    public Set Set { get; set; }
+    public required string CollectorNumber { get; set; }
+    public required string FoilType { get; set; }
+    public required string Language { get; set; }
+    public required string Name { get; set; }
+    public required string ScryfallApiUri { get; set; }
+    public required Guid ScryfallId { get; set; }
+    public required string ScryfallUri { get; set; }
+    public required Set Set { get; set; }
 }

--- a/server/Models/Reference/Card.cs
+++ b/server/Models/Reference/Card.cs
@@ -7,8 +7,8 @@ public class Card
     public required string FoilType { get; set; }
     public required string Language { get; set; }
     public required string Name { get; set; }
-    public required string ScryfallApiUri { get; set; }
+    //public required string ScryfallApiUri { get; set; }
     public required Guid ScryfallId { get; set; }
-    public required string ScryfallUri { get; set; }
-    public required Set Set { get; set; }
+    //public required string ScryfallUri { get; set; }
+    public required string SetCode { get; set; }
 }

--- a/server/Models/Reference/Card.cs
+++ b/server/Models/Reference/Card.cs
@@ -1,0 +1,14 @@
+
+namespace CardboardArchivistApi.Models.Reference;
+
+public class Card
+{
+    public string CollectorNumber { get; set; }
+    public string FoilType { get; set; }
+    public string Language { get; set; }
+    public string Name { get; set; }
+    public string ScryfallApiUri { get; set; }
+    public Guid ScryfallId { get; set; }
+    public string ScryfallUri { get; set; }
+    public Set Set { get; set; }
+}

--- a/server/Models/Reference/Card.cs
+++ b/server/Models/Reference/Card.cs
@@ -5,6 +5,7 @@ public class Card
 {
     public required string CollectorNumber { get; set; }
     public required string FoilType { get; set; }
+    public required Guid Id { get; set; }
     public required string Language { get; set; }
     public required string Name { get; set; }
     //public required string ScryfallApiUri { get; set; }

--- a/server/Models/Reference/SearchCards.cs
+++ b/server/Models/Reference/SearchCards.cs
@@ -1,0 +1,8 @@
+namespace CardboardArchivistApi.Models.Reference;
+
+public class SearchCards
+{
+    public string? Name { get; set; }
+    public string? SetCode { get; set; }
+    public string? CollectorNumber { get; set; }
+}

--- a/server/Models/Reference/Set.cs
+++ b/server/Models/Reference/Set.cs
@@ -5,6 +5,6 @@ public class Set
     public required string Code { get; set; }
     public required string Name { get; set; }
     public required Guid ScryfallId { get; set; }
-    public required string ScryfallApiUri { get; set; }
-    public required string ScryfallUri { get; set; }
+    // public required string ScryfallApiUri { get; set; }
+    // public required string ScryfallUri { get; set; }
 }

--- a/server/Models/Reference/Set.cs
+++ b/server/Models/Reference/Set.cs
@@ -2,9 +2,9 @@ namespace CardboardArchivistApi.Models.Reference;
 
 public class Set
 {
-    public string Code { get; set; }
-    public string Name { get; set; }
-    public Guid ScryfallId { get; set; }
-    public string ScryfallApiUri { get; set; }
-    public string ScryfallUri { get; set; }
+    public required string Code { get; set; }
+    public required string Name { get; set; }
+    public required Guid ScryfallId { get; set; }
+    public required string ScryfallApiUri { get; set; }
+    public required string ScryfallUri { get; set; }
 }

--- a/server/Models/Reference/Set.cs
+++ b/server/Models/Reference/Set.cs
@@ -1,0 +1,10 @@
+namespace CardboardArchivistAPI.Models.Reference;
+
+public class Set
+{
+    public string Code { get; set; }
+    public string Name { get; set; }
+    public Guid ScryfallId { get; set; }
+    public string ScryfallApiUri { get; set; }
+    public string ScryfallUri { get; set; }
+}

--- a/server/Models/Reference/Set.cs
+++ b/server/Models/Reference/Set.cs
@@ -1,4 +1,4 @@
-namespace CardboardArchivistAPI.Models.Reference;
+namespace CardboardArchivistApi.Models.Reference;
 
 public class Set
 {

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,4 +1,4 @@
-using CardboardArchivistAPI.Services;
+using CardboardArchivistApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -6,9 +6,13 @@ builder.Services.AddControllers();
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(config =>
+{
+    config.CustomSchemaIds(model => model.FullName);
+});
 
 builder.Services.AddScoped<ICardService, InMemoryCardService>();
+builder.Services.AddScoped<IReferenceService, InMemoryReferenceService>();
 
 var app = builder.Build();
 

--- a/server/Services/ICardService.cs
+++ b/server/Services/ICardService.cs
@@ -1,6 +1,6 @@
-using CardboardArchivistAPI.Models.Collection;
+using CardboardArchivistApi.Models.Collection;
 
-namespace CardboardArchivistAPI.Services;
+namespace CardboardArchivistApi.Services;
 
 public interface ICardService
 {

--- a/server/Services/IDatabase.cs
+++ b/server/Services/IDatabase.cs
@@ -1,4 +1,4 @@
-namespace CardboardArchivistAPI.Services;
+namespace CardboardArchivistApi.Services;
 
 public interface IDatabase
 {

--- a/server/Services/IReferenceService.cs
+++ b/server/Services/IReferenceService.cs
@@ -6,4 +6,5 @@ public interface IReferenceService
 {
     public Card? GetCard(Guid id);
     public Set? GetSet(Guid id);
+    public List<Card> SearchCards(SearchCards searchCards);
 }

--- a/server/Services/IReferenceService.cs
+++ b/server/Services/IReferenceService.cs
@@ -1,0 +1,9 @@
+using CardboardArchivistApi.Models.Reference;
+
+namespace CardboardArchivistApi.Services;
+
+public interface IReferenceService
+{
+    public Card? GetCard(Guid id);
+    public Set? GetSet(Guid id);
+}

--- a/server/Services/InMemoryCardService.cs
+++ b/server/Services/InMemoryCardService.cs
@@ -8,29 +8,29 @@ public class InMemoryCardService : ICardService
     [
         new()
         {
-            UUID = "card-uuid-1",
-            ReferenceUUID = "reference-uuid-1",
-            DeckUUID = "deck-uuid-1"
+            Id = "card-uuid-1",
+            ReferenceId = new Guid("00000000-0000-0000-0001-000000000001"),
+            DeckId = new Guid("00000000-0000-0000-0002-000000000001")
         },
         new()
         {
-            UUID = "card-uuid-2",
-            ReferenceUUID = "reference-uuid-1"
+            Id = "card-uuid-2",
+            ReferenceId = new Guid("00000000-0000-0000-0001-000000000002")
         },
         new()
         {
-            UUID = "card-uuid-3",
-            ReferenceUUID = "reference-uuid-2",
-            DeckUUID = "deck-uuid-2"
+            Id = "card-uuid-3",
+            ReferenceId = new Guid("00000000-0000-0000-0001-000000000003"),
+            DeckId = new Guid("00000000-0000-0000-0002-000000000001")
         }
     ];
     private static int uuidCounter = 4;
 
     public string? Create(Card card)
     {
-        card.UUID = $"card-uuid-{uuidCounter++}";
+        card.Id = $"card-uuid-{uuidCounter++}";
         Cards.Add(card);
-        return card.UUID;
+        return card.Id;
     }
     
     public bool Delete(string UUID)
@@ -42,18 +42,18 @@ public class InMemoryCardService : ICardService
         return true;
     }
     
-    public Card? Get(string UUID) => Cards.FirstOrDefault(card => card.UUID!.Equals(UUID));
+    public Card? Get(string UUID) => Cards.FirstOrDefault(card => card.Id!.Equals(UUID));
 
-    private int GetIndex(string UUID) => Cards.FindIndex(card => card.UUID!.Equals(UUID));
+    private int GetIndex(string UUID) => Cards.FindIndex(card => card.Id!.Equals(UUID));
 
     public List<Card> GetAll() => Cards;
 
     public void Update(Card card)
     {
-        if (card.UUID is null)
+        if (card.Id is null)
             // TODO: Perhaps throw and handle an exception here?
             return;
-        int cardToUpdateIndex = GetIndex(card.UUID!);
+        int cardToUpdateIndex = GetIndex(card.Id!);
         if (cardToUpdateIndex < 0)
             return;
         Cards[cardToUpdateIndex] = card;

--- a/server/Services/InMemoryCardService.cs
+++ b/server/Services/InMemoryCardService.cs
@@ -1,6 +1,6 @@
-using CardboardArchivistAPI.Models.Collection;
+using CardboardArchivistApi.Models.Collection;
 
-namespace CardboardArchivistAPI.Services;
+namespace CardboardArchivistApi.Services;
 
 public class InMemoryCardService : ICardService
 {

--- a/server/Services/InMemoryReferenceService.cs
+++ b/server/Services/InMemoryReferenceService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using CardboardArchivistApi.Models.Reference;
 
 namespace CardboardArchivistApi.Services;
@@ -50,15 +51,36 @@ public class InMemoryReferenceService : IReferenceService
 
     public List<Card> SearchCards(SearchCards searchCards)
     {
+        List<(string, string)> searchOptions = [];
+        
+        foreach(PropertyInfo propertyInfo in searchCards.GetType().GetProperties())
+        {
+            var propertyValue = propertyInfo.GetValue(searchCards);
+            if (propertyValue is not null)
+            {
+                (string, string) searchOption = (propertyInfo.Name, propertyValue.ToString()!);
+                Console.WriteLine(searchOption);
+                searchOptions.Add(searchOption);
+            }
+        }
+        if (searchOptions.Count == 0)
+            return Cards;
         return Cards.Where(card => 
         {
             bool match = true;
-            if (!String.IsNullOrWhiteSpace(searchCards.Name))
-                match = match && card.Name == searchCards.Name;
-            if (!String.IsNullOrWhiteSpace(searchCards.SetCode))
-                match = match && card.SetCode == searchCards.SetCode;
-            if (!String.IsNullOrWhiteSpace(searchCards.CollectorNumber))
-                match = card.CollectorNumber == searchCards.CollectorNumber;
+            // if (!String.IsNullOrWhiteSpace(searchCards.Name))
+            //     match = match && card.Name == searchCards.Name;
+            // if (!String.IsNullOrWhiteSpace(searchCards.SetCode))
+            //     match = match && card.SetCode == searchCards.SetCode;
+            // if (!String.IsNullOrWhiteSpace(searchCards.CollectorNumber))
+            //     match = card.CollectorNumber == searchCards.CollectorNumber;
+            foreach((string, string) searchOption in searchOptions)
+            {
+                string? cardValue = card.GetType().GetProperty(searchOption.Item1)?.GetValue(card)?.ToString();
+                Console.WriteLine(cardValue);
+                if (cardValue is not null)
+                    match = match && cardValue == searchOption.Item2;
+            }
             return match;
             
         }).ToList();

--- a/server/Services/InMemoryReferenceService.cs
+++ b/server/Services/InMemoryReferenceService.cs
@@ -1,0 +1,50 @@
+using CardboardArchivistApi.Models.Reference;
+
+namespace CardboardArchivistApi.Services;
+
+public class InMemoryReferenceService : IReferenceService
+{
+    private static List<Card> Cards { get; } = 
+    [
+        new()
+        {
+            CollectorNumber = "446",
+            FoilType = "",
+            Language = "en",
+            Name = "Vivid Meadow",
+            // ScryfallApiUri = "https://api.scryfall.com/cards/625a42b4-d88c-48e0-96b1-77388ca48810",
+            ScryfallId = new Guid("625a42b4-d88c-48e0-96b1-77388ca48810"),
+            SetCode = "NCC"
+        }
+    ];
+
+    // private static List<Set> Sets { get; } =
+    // {
+    //     new()
+    //     {
+    //         Code = "NCC",
+    //         Name = "New Capenna Commander",
+    //         ScryfallId = new Guid("c51de34b-d4d6-4179-a432-573744ded119"),
+    //         ScryfallApiUri = "https://api.scryfall.com/sets/c51de34b-d4d6-4179-a432-573744ded119"
+    //     }
+    // }
+
+    public Card? GetCard(Guid id)
+    {
+        return Cards.FirstOrDefault(card => card.ScryfallId == id);
+    }
+
+    public Card? GetCard(string name, string setCode, string collectorNumber)
+    {
+        return Cards.FirstOrDefault(card =>
+            card.Name == name &&
+            card.SetCode == setCode &&
+            card.CollectorNumber == collectorNumber);
+    }
+
+    public Set? GetSet(Guid id)
+    {
+        // return Sets.FirstOrDefault(set => set.Id.Equals(id));
+        throw new NotImplementedException();
+    }
+}

--- a/server/Services/InMemoryReferenceService.cs
+++ b/server/Services/InMemoryReferenceService.cs
@@ -9,42 +9,54 @@ public class InMemoryReferenceService : IReferenceService
         new()
         {
             CollectorNumber = "446",
-            FoilType = "",
+            FoilType = "nonfoil",
+            Id = new Guid("b2837ab2-ddf2-4503-a73b-daf9fe156614"),
             Language = "en",
             Name = "Vivid Meadow",
-            // ScryfallApiUri = "https://api.scryfall.com/cards/625a42b4-d88c-48e0-96b1-77388ca48810",
             ScryfallId = new Guid("625a42b4-d88c-48e0-96b1-77388ca48810"),
             SetCode = "NCC"
+        },
+        new()
+        {
+            CollectorNumber = "17",
+            FoilType = "foil",
+            Id = new Guid("3e29a77b-f658-4268-8e5e-dbd432edc475"),
+            Language = "en",
+            Name = "Healing Hands",
+            ScryfallId = new Guid("9a26559c-0ac5-42a7-b6ac-b39938c31026"),
+            SetCode = "ORI"
+        },
+        new()
+        {
+            CollectorNumber = "17",
+            FoilType = "nonfoil",
+            Id = new Guid("d0397b43-1f99-4c4c-9d8d-a3cc775f19ee"),
+            Language = "en",
+            Name = "Healing Hands",
+            ScryfallId = new Guid("9a26559c-0ac5-42a7-b6ac-b39938c31026"),
+            SetCode = "ORI"
         }
     ];
 
-    // private static List<Set> Sets { get; } =
-    // {
-    //     new()
-    //     {
-    //         Code = "NCC",
-    //         Name = "New Capenna Commander",
-    //         ScryfallId = new Guid("c51de34b-d4d6-4179-a432-573744ded119"),
-    //         ScryfallApiUri = "https://api.scryfall.com/sets/c51de34b-d4d6-4179-a432-573744ded119"
-    //     }
-    // }
-
     public Card? GetCard(Guid id)
     {
-        return Cards.FirstOrDefault(card => card.ScryfallId == id);
-    }
-
-    public Card? GetCard(string name, string setCode, string collectorNumber)
-    {
-        return Cards.FirstOrDefault(card =>
-            card.Name == name &&
-            card.SetCode == setCode &&
-            card.CollectorNumber == collectorNumber);
+        return Cards.FirstOrDefault(card => card.Id == id);
     }
 
     public Set? GetSet(Guid id)
     {
-        // return Sets.FirstOrDefault(set => set.Id.Equals(id));
         throw new NotImplementedException();
+    }
+
+    public List<Card> SearchCards(SearchCards searchCards)
+    {
+        return Cards.Where(card => 
+        {
+            bool nameMatch = !String.IsNullOrWhiteSpace(searchCards.Name) && card.Name == searchCards.Name;
+            bool setCodeMatch = !String.IsNullOrWhiteSpace(searchCards.SetCode) && card.SetCode == searchCards.SetCode;
+            bool collectorNumberMatch = !String.IsNullOrWhiteSpace(searchCards.CollectorNumber) && card.CollectorNumber == searchCards.CollectorNumber;
+            return nameMatch && setCodeMatch && collectorNumberMatch;
+            
+        }).ToList();
     }
 }

--- a/server/Services/InMemoryReferenceService.cs
+++ b/server/Services/InMemoryReferenceService.cs
@@ -52,10 +52,14 @@ public class InMemoryReferenceService : IReferenceService
     {
         return Cards.Where(card => 
         {
-            bool nameMatch = !String.IsNullOrWhiteSpace(searchCards.Name) && card.Name == searchCards.Name;
-            bool setCodeMatch = !String.IsNullOrWhiteSpace(searchCards.SetCode) && card.SetCode == searchCards.SetCode;
-            bool collectorNumberMatch = !String.IsNullOrWhiteSpace(searchCards.CollectorNumber) && card.CollectorNumber == searchCards.CollectorNumber;
-            return nameMatch && setCodeMatch && collectorNumberMatch;
+            bool match = true;
+            if (!String.IsNullOrWhiteSpace(searchCards.Name))
+                match = match && card.Name == searchCards.Name;
+            if (!String.IsNullOrWhiteSpace(searchCards.SetCode))
+                match = match && card.SetCode == searchCards.SetCode;
+            if (!String.IsNullOrWhiteSpace(searchCards.CollectorNumber))
+                match = card.CollectorNumber == searchCards.CollectorNumber;
+            return match;
             
         }).ToList();
     }


### PR DESCRIPTION
This PR adds a rudimentary controller for handling card references.

The Reference.Card model represents the text, game rules, and collector information present in each card. Such information includes:
* Name
* Rules text
* Set information (collector number, set code/symbol)

The model also includes an external reference field. This will be used in the future to retrieve more information about cards from external databases. In the case of Magic: the Gathering, this is a Scryfall URI, but this field can be used for other trading card systems.